### PR TITLE
Updated media_configure to get correct pipeline

### DIFF
--- a/include/image2rtsp.h
+++ b/include/image2rtsp.h
@@ -121,7 +121,7 @@ struct _GstRTSPMediaPrivate
 	GstClockTime rtx_time;        /* protected by lock */
 	guint latency;                /* protected by lock */
 	GstClock *clock;              /* protected by lock */
-	GstRTSPPublishClockMode publish_clock_mode;
+	//GstRTSPPublishClockMode publish_clock_mode;
 };
 
 #endif

--- a/src/video.cpp
+++ b/src/video.cpp
@@ -95,10 +95,13 @@ GstRTSPServer *Image2RTSPNodelet::rtsp_server_create() {
  * pipeline and configure our appsrc */
 static void media_configure(GstRTSPMediaFactory *factory, GstRTSPMedia *media, GstElement **appsrc)
 {
-	GstElement *pipeline = media->priv->pipeline;
+	GstElement *pipeline = gst_rtsp_media_get_element (media);
+
 	*appsrc = gst_bin_get_by_name(GST_BIN(pipeline), "imagesrc");
 	/* this instructs appsrc that we will be dealing with timed buffer */
 	gst_util_set_object_arg(G_OBJECT(*appsrc), "format", "time");
+
+	gst_object_unref (pipeline);
 }
 
 


### PR DESCRIPTION
Great work with the node. I had some problems using it. Fist it did not compile because GstRTSPPublishClockMode was not found, so I commented that out.

After that I could not get the steaming to work. I updated how you get the pipeline in the media_configure function, and then I got it to work. The pipeline object was NULL previously.

Hope you can include the patch.